### PR TITLE
`max-width` for body, better with for narrow or very wide screens?

### DIFF
--- a/html/css/style.css
+++ b/html/css/style.css
@@ -2,7 +2,7 @@
 
 body {
   font-family: "Alegreya Sans", Helvatica, sans-serif;
-  width: 60%;
+  max-width: 18cm; // Roughly the width of an A4 paper - margins
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
On my large monitor, I personally found a body width of 60% to be too wide. On a small screen (tablet), I found 60% to be too narrow. The attached changes this using the max-width attribute to limit the page width to roughly A4 paper minus margins.