### PR TITLE
Typos correction and suggestions

### DIFF
--- a/Chapters/Population_structure.tex
+++ b/Chapters/Population_structure.tex
@@ -585,7 +585,7 @@ recombination (i.e. an odd number of crossing over events) occurs between the
 two parental haplotypes, then $\nicefrac{1}{2}$ the time the child receives an
 $Ab$ haplotype and $\nicefrac{1}{2}$ the time the child receives an $aB$
 haplotype. See Figure \ref{fig:recom_cartoon}. Effectively, recombination breaks up the association between loci.
-For linked markers we'll define the recombination fraction ($x$) to be the probability
+For linked markers we'll define the recombination fraction ($c$) to be the probability
 of an odd number of crossing over events between our loci in a single
 meiosis. The recombination fraction between a pair of loci can range from $0$ to
 $\nicefrac{1}{2}$, with $c=\nicefrac{1}{2}$ corresponding markers far

--- a/Chapters/Population_structure.tex
+++ b/Chapters/Population_structure.tex
@@ -100,7 +100,7 @@ $H_{S}^{(i)} = 2 p_{i} q_{i}$ is the expected heterozygosity in subpopulation
 $i$. It follows that the  average heterozygosity of the
 sub-populations $\bar{H}_S  \leq
 H_T$, and so $\bar{\fst} \geq 0$ and $\bar{\fis} \leq \bar{\fit}$. This observation that the average
-  heterozygosity of the sub-populations must be less than of equal to
+  heterozygosity of the sub-populations must be less than or equal to
   that of the total
   population is called the Wahlund effect \citep{wahlund1928zusammensetzung}. Furthermore, if we have multiple sites, we can replace $H_I$, $H_S$, and
 $H_T$ with their averages across loci (as above).\sidenote[][-0.5cm]{Averaging heterozygosity across loci first, then calculating $\fst$, rather than calculating $\fst$ for each locus individually and then taking the average, has better statistical properties as statistical noise in the denominator is averaged out. }
@@ -179,7 +179,7 @@ warblers compared to the combined sample.\\
 
 Let's now return to Wright's definition of the $F$-statistics as correlations
 between random gametes, drawn from the same level $X$, relative to level $Y$.
-Without loss of generality, we may think about $X$ as individuals and $S$ as
+Without loss of generality, we may think about $X$ as individuals and $Y$ as
 the subpopulation.  Rewriting $\fis$ in terms of the observed homozygote
 frequencies ($f_{11}$, $f_{22}$) and expected homozygosities ($p_{S}^2$,
 $q_{S}^2$) we find
@@ -188,7 +188,7 @@ $q_{S}^2$) we find
 p_S^2 - q_S^2}{2p_Sq_S},
 \label{eqn:Fascorr}
 \end{equation}
-using the fact that $p^2+2pq+q^2=1$, and $f_{12} = 1 - f_{11} - f_{12}$. The
+using the fact that $p^2+2pq+q^2=1$, and $f_{12} = 1 - f_{11} - f_{22}$. The
 form of eqn.\ (\ref{eqn:Fascorr}) reveals that $\fis$ is the covariance between
 pairs of alleles found in an individual, divided by the expected variance under
 binomial sampling. Thus, $F$-statistics can be understood as the correlation
@@ -255,7 +255,7 @@ allele frequency of allele $A_1$ at locus $l$ in population $k$ is denoted by
 $p_{k,l}$, so that the allele frequencies in population 1 are $p_{1,1},\cdots
 p_{1,L}$ and population 2 are $p_{2,1},\cdots p_{2,L}$ and so on.
 
-You genotype a new individual from an unknown population at these $L$ loci. This individual's genotype at locus $l$ is $g_l$, where $g_l$ denotes the number of copies of allele $A_1$ this individual carries at this locus ($g_l=0,1,2$).
+You genotype a new individual from an unknown population at these $S$ loci. This individual's genotype at locus $l$ is $g_l$, where $g_l$ denotes the number of copies of allele $A_1$ this individual carries at this locus ($g_l=0,1,2$).
 %JRI: is this formally the definition of a set? should if be $g_l={0,1,2}$ ?
 
 The probability of this individual's genotype at locus $l$ conditional on coming from population $k$, i.e. their alleles being a random HW draw from population $k$, is
@@ -275,7 +275,7 @@ Assuming that the loci are independent, the probability of the individual's geno
 
 % TODO: deleted "new" in bayes -- this is confusing I think for students
 We wish to know the probability that this new individual comes from population
-$k$, i.e. $P(\textrm{pop k} | \textrm{ind.})$. We can obtain this through Bayes'
+$k$, i.e. $\P(\textrm{pop k} | \textrm{ind.})$. We can obtain this through Bayes'
 rule
 
 \begin{equation}

--- a/Chapters/chapter-01.tex
+++ b/Chapters/chapter-01.tex
@@ -579,7 +579,7 @@ full-sibs share zero alleles identical by descent.\\
 
 One summary of relatedness that will be important is the probability that two
 alleles (I \& J) picked at random, one from each of the two different individuals $i$
-and $j$, are identical by descent ($P(\text{I\&J IBD})$). We call this quantity the \emph{coefficient
+and $j$, are identical by descent ($\P(\text{I\&J IBD})$). We call this quantity the \emph{coefficient
 of kinship} of individuals $i$ and $j$, and denote it by $F_{ij}$. It is
 calculated as
 %JRI: you come back to inbreeding later, but perhaps worth mentioning here that you are only considering outbred Individuals
@@ -601,7 +601,7 @@ or $2$ alleles IBD, an example of using the Law of Total Probability (see Append
 \eqn \eqref{eqn:law_tot_prob}).  We've then, in \eqn \ref{eqn:coeffkinship}, used the fact that we can
 calculate our condition probabilities of  I \& J being IBD using the
 rules of Mendelian transmision. Consider the probability $
-P(\text{I\&J IBD} |~ \text{i\&j  1 IBD})$, i.e. that our
+\P(\text{I\&J IBD} |~ \text{i\&j  1 IBD})$, i.e. that our
 pair of alleles ($I$ \& $J$) drawn from individuals $i$ and $j$ are IBD given that
 $i$ and $j$ share one allele IBD, this is a $\nicefrac{1}{4}$ as we need to
 draw the allele that is IBD from both $i$ and $j$, i.e. drawing both black
@@ -840,7 +840,7 @@ by two different routes from the same ancestor. Thus, the probability that an
 offspring is homozygous for $A_1$ is
 
 \begin{align}
-P(A_1 A_1) & = \P(A_1 A_1 |\textrm{I \& J not IBD} ) \P (\textrm{I\&J
+\P(A_1 A_1) & = \P(A_1 A_1 |\textrm{I \& J not IBD} ) \P (\textrm{I\&J
   not IBD} ) + \P(A_1 A_1 |\textrm{I\&J IBD} ) \P (\textrm{I\&J IBD}) \nonumber\\
              &= p^2(1-F_{ij})  + pF_{ij}.
 \end{align}

--- a/Chapters/intro.tex
+++ b/Chapters/intro.tex
@@ -24,7 +24,7 @@ theory.\\
   \citet{box:79}.}  % https://en.wikipedia.org/wiki/All_models_are_wrong#Quotations_of_George_Box
 % http://www.dtic.mil/dtic/tr/fulltext/u2/a070213.pdf
 
-rWhile the models we will develop will seem na\"{\i}ve, and indeed they are, they are
+While the models we will develop will seem na\"{\i}ve, and indeed they are, they are
 nonetheless incredibly useful and powerful. Throughout the course we will see
 that these simple models often yield accurate predictions, such that much of our
 understanding of the process of evolution is built on these models. We will


### PR DESCRIPTION
With the Bradburd Lab at MSU, we read the first part of your amazing notes, so well done! Thank you! 
We're glad to help fixing some typos we noticed. We also have a couple of suggestions (unfortunately Makrdown on Github does not support equations, but I leave them in markdown notation). These notes were provided by @bobweek:

- pg 31, eqn (2.11), suggestion: use $F_{A_i}$ instead of $f_{A_i}$ since $f$ used to denote genotype frequencies.

- pg 43, eqn (3.7): confusing notation. 
  - what is $\mathrm{Var}(p_1,\dots,p_K)$?
  - $\bar p$ is not a random variable, so what is $\mathrm{Var}(\bar p)$?
  - suggestion: set $X_i\sim\mathrm{Bin}(p_i)$ and $X\sim\mathrm{Bin}(\bar p)$, then $F_{ST}=\frac{\overline{\mathrm{Var}(X_i)}}{\mathrm{Var}(X)}.$

- pg 44, eqn (3.8): confusing/informal way of writing a probability. Would be more clear to write the probability of an event, e.g., the probability of the event $g_l=0$ given pop $=k$ would be written
$$\mathbb{P}(g_l=0 \ | \ \mathrm{pop}=k)=(1-p_{kl})^2.$$

- pg 44, eqn (3.9): following the above comment, in my notes i wrote $g=(g_1,\dots,g_S)$ as the unkown genotype and $\gamma=(\gamma_1,\dots,\gamma_S)$ as an instance so that the probability of an individual with a particular genotype, given pop $=k$ is
$$\mathbb{P}(g=\gamma \ | \ \mathrm{pop}=k)=\prod_{l=1}^S\mathbb{P}(g_l=\gamma_l \ | \ \mathrm{pop}=k).$$