### PR TITLE
Update Interaction_selection_mut_mig.tex

### DIFF
--- a/Chapters/Interaction_selection_mut_mig.tex
+++ b/Chapters/Interaction_selection_mut_mig.tex
@@ -477,8 +477,8 @@ Upon the west beach sits the West Beast.
 Each beach beast thinks he's the best beast.'' --
 Theodor Seuss Geisel} We'll think of a bi-allelic model where
 the homozygotes for allele 1 have an additive selective advantage $s$
-over allele $2$ homozygotes to the east of our habitat transition (left of
-zero in Figure \ref{fig:cline_main}). This flips to allele $2$ having the same advantage $s$ west of the transition (right of zero).  If you've read this send Prof Coop a picture of
+over allele $2$ homozygotes to the west of our habitat transition (left of
+zero in Figure \ref{fig:cline_main}). This flips to allele $2$ having the same advantage $s$ east of the transition (right of zero).  If you've read this send Prof Coop a picture of
 the East and West Beast.
 
 \begin{figure}
@@ -541,8 +541,7 @@ ideas in more detail.
 \caption[][2cm]{Allele frequency clines of two pesticide resistance
   alleles, at the {\it Ace 1} and {\it Ester} genes, in the
   mosquito {\it Culex pipiens}. The dotted line shows where we move from pesticide-treated to untreated
- areas as we move away from the French coast. The dots show observed allele frequencies, the solid lines clines fit under a migration-selection
-  balance model of a cline. These allele frequencies represent
+ areas as we move away from the French coast. The dots show observed allele frequencies, the solid lines a smoothed fit. These allele frequencies represent
  collections over two summers, the frequencies of the alleles are
   substantially reduced in the winter due to the reduced use of
   pesticides. Data from

--- a/Chapters/Interaction_selection_mut_mig.tex
+++ b/Chapters/Interaction_selection_mut_mig.tex
@@ -569,7 +569,7 @@ They
 estimated that a higher selective advantage for the {\it Ace 1} allele
 than{\it Ester} allele ($s=0.33$ and $s=0.19$  respectively) and a
 higher cost to the {\it Ace 1} allele than
-{\it Ester} allele in untreated areas ($c=0.11$ and $c=07$
+{\it Ester} allele in untreated areas ($c=0.11$ and $c=0.07$
 respectively) potentially explaining the less extreme cline for {\it Ester}
 allele than the  {\it Ace 1} allele. Despite these strong selection pressures, we still see a cline
 over tens of kilometers because dispersal is relatively high ($\sigma=


### PR DESCRIPTION
switched east and west (north is usually "up" and I don't think the Seuss poem implies a switch?)

Culex graph legend implied solid line was a model fit but R code looks to be just a lowess so I changed the legend.